### PR TITLE
Allow If-Modified-Since header for REST API

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -23,7 +23,7 @@ var proxyCounter = 0;
 app.all('/proxy/?*', function(req, res) {
   res.header('Access-Control-Allow-Origin', '*');
   res.header('Access-Control-Allow-Methods', 'GET,POST,PATCH,PUT,DELETE');
-  res.header('Access-Control-Allow-Headers', 'Authorization,Content-Type,Salesforceproxy-Endpoint,X-Authorization,X-SFDC-Session,SOAPAction,SForce-Auto-Assign');
+  res.header('Access-Control-Allow-Headers', 'Authorization,Content-Type,Salesforceproxy-Endpoint,X-Authorization,X-SFDC-Session,SOAPAction,SForce-Auto-Assign,If-Modified-Since');
   res.header('Access-Control-Expose-Headers', 'SForce-Limit-Info');
   if (req.method === 'OPTIONS') {
     res.end();


### PR DESCRIPTION
Allow If-Modified-Since header to be sent for compatibility with the
Salesforce REST API.
